### PR TITLE
Allow customization of elfeed header powerline separator

### DIFF
--- a/elfeed-goodies-search-mode.el
+++ b/elfeed-goodies-search-mode.el
@@ -107,10 +107,10 @@ and the length of the active queue."
   (if (zerop (elfeed-db-last-update))
       (elfeed-search--intro-header)
     (let* ((separator-left (intern (format "powerline-%s-%s"
-                                           "arrow-fade"
+                                           elfeed-goodies-powerline-default-separator
                                            (car powerline-default-separator-dir))))
            (separator-right (intern (format "powerline-%s-%s"
-                                            "arrow-fade"
+                                            elfeed-goodies-powerline-default-separator
                                             (cdr powerline-default-separator-dir))))
            (db-time (seconds-to-time (elfeed-db-last-update)))
            (stats (-elfeed/feed-stats))

--- a/elfeed-goodies-show-mode.el
+++ b/elfeed-goodies-show-mode.el
@@ -35,10 +35,10 @@ When zero or negative, the fringes are left untouched."
                        (elfeed-feed-title feed)))
 
          (separator-left (intern (format "powerline-%s-%s"
-                                         "arrow-fade"
+                                         elfeed-goodies-powerline-default-separator
                                          (car powerline-default-separator-dir))))
          (separator-right (intern (format "powerline-%s-%s"
-                                          "arrow-fade"
+                                          elfeed-goodies-powerline-default-separator
                                           (cdr powerline-default-separator-dir))))
          (lhs (list
                (powerline-raw (concat " " (propertize tags-str 'face 'elfeed-search-tag-face) " ") 'powerline-active2 'r)

--- a/elfeed-goodies.el
+++ b/elfeed-goodies.el
@@ -34,12 +34,30 @@
   "Customisation group for `elfeed-goodies'."
   :group 'comm)
 
-(defcustom elfeed-goodies/powerline-separators t
-  "Toggle powerline separator use on or off within Elfeed buffers.
+(defcustom elfeed-goodies-powerline-default-separator 'arrow-fade
+  "The separator to use for elfeed headers.
 
-When disabled, powerline will still be in use, but without separators."
+Valid Values: alternate, arrow, arrow-fade, bar, box, brace,
+butt, chamfer, contour, curve, rounded, roundstub, wave, zigzag,
+utf-8."
   :group 'elfeed-goodies
-  :type 'boolean)
+  :type '(choice (const alternate)
+                 (const arrow)
+                 (const arrow-fade)
+                 (const bar)
+                 (const box)
+                 (const brace)
+                 (const butt)
+                 (const chamfer)
+                 (const contour)
+                 (const curve)
+                 (const rounded)
+                 (const roundstub)
+                 (const slant)
+                 (const wave)
+                 (const zigzag)
+                 (const utf-8)
+                 (const nil)))
 
 (defun maybe-separator (separator-func face-left face-right)
   (if elfeed-goodies/powerline-separators


### PR DESCRIPTION
- elfeed-goodies.el (elfeed-goodies-powerline-default-separator): Define
  new var
- elfeed-goodies-search-mode.el (elfeed-goodies/search-header-draw): Use it
- elfeed-goodies-show-mode.el (elfeed-goodies/entry-header-line): Use it
