### PR TITLE
Add a way to html decode the title of all feeds

### DIFF
--- a/elfeed-goodies-new-entry-hooks.el
+++ b/elfeed-goodies-new-entry-hooks.el
@@ -26,7 +26,8 @@
 
 (defun elfeed-goodies/html-decode-title (entry)
   (let ((tags (elfeed-deref (elfeed-entry-tags entry))))
-    (if (cl-intersection tags elfeed-goodies/html-decode-title-tags)
+    (if (or (equal elfeed-goodies/html-decode-title-tags '(:all))
+            (cl-intersection tags elfeed-goodies/html-decode-title-tags))
         (let* ((original (elfeed-deref (elfeed-entry-title entry)))
                (replace (decode-entities original)))
           (setf (elfeed-entry-title entry) replace)))))


### PR DESCRIPTION
Setting elfeed-goodies/html-decode-title-tags to '(:all) will decode all titles, regardless of tags.
