### PR TITLE
Remove dependencies on noflet and powerline

### DIFF
--- a/elfeed-goodies-show-mode.el
+++ b/elfeed-goodies-show-mode.el
@@ -13,7 +13,6 @@
 
 (require 'elfeed)
 (require 'elfeed-goodies)
-(require 'powerline)
 (require 'ace-jump-mode)
 (require 'cl-lib)
 
@@ -22,38 +21,39 @@
   :group 'elfeed-goodies
   :type 'integer)
 
-(defun elfeed-goodies/entry-header-line ()
-  (let* ((title (elfeed-entry-title elfeed-show-entry))
-         (title-faces (elfeed-search--faces (elfeed-entry-tags elfeed-show-entry)))
-         (tags (elfeed-entry-tags elfeed-show-entry))
-         (tags-str (mapconcat #'symbol-name tags ", "))
-         (date (seconds-to-time (elfeed-entry-date elfeed-show-entry)))
-         (feed (elfeed-entry-feed elfeed-show-entry))
-         (entry-author (elfeed-meta elfeed-show-entry :author))
-         (feed-title (if entry-author
-                         (concat entry-author " (" (elfeed-feed-title feed) ")")
-                       (elfeed-feed-title feed)))
+(with-eval-after-load 'powerline
+  (defun elfeed-goodies/entry-header-line ()
+    (let* ((title (elfeed-entry-title elfeed-show-entry))
+           (title-faces (elfeed-search--faces (elfeed-entry-tags elfeed-show-entry)))
+           (tags (elfeed-entry-tags elfeed-show-entry))
+           (tags-str (mapconcat #'symbol-name tags ", "))
+           (date (seconds-to-time (elfeed-entry-date elfeed-show-entry)))
+           (feed (elfeed-entry-feed elfeed-show-entry))
+           (entry-author (elfeed-meta elfeed-show-entry :author))
+           (feed-title (if entry-author
+                           (concat entry-author " (" (elfeed-feed-title feed) ")")
+                         (elfeed-feed-title feed)))
 
-         (separator-left (intern (format "powerline-%s-%s"
-                                         elfeed-goodies/powerline-default-separator
-                                         (car powerline-default-separator-dir))))
-         (separator-right (intern (format "powerline-%s-%s"
-                                          elfeed-goodies/powerline-default-separator
-                                          (cdr powerline-default-separator-dir))))
-         (lhs (list
-               (powerline-raw (concat " " (propertize tags-str 'face 'elfeed-search-tag-face) " ") 'powerline-active2 'r)
-               (funcall separator-left 'powerline-active2 'powerline-active1)
-               (powerline-raw (concat " " (propertize title 'face title-faces) " ") 'powerline-active1 'l)
-               (funcall separator-left 'powerline-active1 'mode-line)))
-         (rhs (list
-               (funcall separator-right 'mode-line 'powerline-active1)
-               (powerline-raw (concat " " (propertize feed-title 'face 'elfeed-search-feed-face) " ") 'powerline-active1)
-               (funcall separator-right 'powerline-active1 'powerline-active2)
-               (powerline-raw (format-time-string "%Y-%m-%d %H:%M:%S %z " date) 'powerline-active2 'l))))
-    (concat
-     (powerline-render lhs)
-     (powerline-fill 'mode-line (powerline-width rhs))
-     (powerline-render rhs))))
+           (separator-left (intern (format "powerline-%s-%s"
+                                           elfeed-goodies/powerline-default-separator
+                                           (car powerline-default-separator-dir))))
+           (separator-right (intern (format "powerline-%s-%s"
+                                            elfeed-goodies/powerline-default-separator
+                                            (cdr powerline-default-separator-dir))))
+           (lhs (list
+                 (powerline-raw (concat " " (propertize tags-str 'face 'elfeed-search-tag-face) " ") 'powerline-active2 'r)
+                 (funcall separator-left 'powerline-active2 'powerline-active1)
+                 (powerline-raw (concat " " (propertize title 'face title-faces) " ") 'powerline-active1 'l)
+                 (funcall separator-left 'powerline-active1 'mode-line)))
+           (rhs (list
+                 (funcall separator-right 'mode-line 'powerline-active1)
+                 (powerline-raw (concat " " (propertize feed-title 'face 'elfeed-search-feed-face) " ") 'powerline-active1)
+                 (funcall separator-right 'powerline-active1 'powerline-active2)
+                 (powerline-raw (format-time-string "%Y-%m-%d %H:%M:%S %z " date) 'powerline-active2 'l))))
+      (concat
+       (powerline-render lhs)
+       (powerline-fill 'mode-line (powerline-width rhs))
+       (powerline-render rhs)))))
 
 (defun elfeed-goodies/show-refresh--plain ()
   (interactive)
@@ -97,8 +97,9 @@
     (ace-jump-do "foo")))
 
 (defun elfeed-goodies/show-mode-setup ()
-  (setq header-line-format '(:eval (elfeed-goodies/entry-header-line))
-        left-margin-width elfeed-goodies/show-mode-padding
+  (when (featurep 'powerline)
+    (setq header-line-format '(:eval (elfeed-goodies/entry-header-line))))
+  (setq left-margin-width elfeed-goodies/show-mode-padding
         right-margin-width elfeed-goodies/show-mode-padding)
   (define-key elfeed-show-mode-map (kbd "M-v") #'elfeed-goodies/show-ace-link))
 

--- a/elfeed-goodies-show-mode.el
+++ b/elfeed-goodies-show-mode.el
@@ -89,11 +89,11 @@
                            candidates)
                      (setq skip (text-property-any (point) (point-max)
                                                    'help-echo nil))))
-                 (nreverse candidates)))))
-    (setq ace-jump-mode-end-hook
-          (list `(lambda ()
-                   (forward-char 1)
-                   (shr-browse-url))))
+                 (nreverse candidates))))
+            (ace-jump-mode-end-hook
+             (list `(lambda ()
+                      (forward-char 1)
+                      (shr-browse-url)))))
     (ace-jump-do "foo")))
 
 (defun elfeed-goodies/show-mode-setup ()

--- a/elfeed-goodies-show-mode.el
+++ b/elfeed-goodies-show-mode.el
@@ -14,8 +14,8 @@
 (require 'elfeed)
 (require 'elfeed-goodies)
 (require 'powerline)
-(require 'noflet)
 (require 'ace-jump-mode)
+(require 'cl-lib)
 
 (defcustom elfeed-goodies/show-mode-padding 0
   "Padding on the side of the `*elfeed-entry*' buffer, in characters."
@@ -74,21 +74,22 @@
 (defun elfeed-goodies/show-ace-link ()
   "Select a link to visit with ace-jump."
   (interactive)
-  (noflet ((ace-jump-search-candidate (str va-list)
-                                      (let ((skip (text-property-any (point-min) (point-max)
-                                                                     'help-echo nil))
-                                            candidates)
-                                        (save-excursion
-                                          (while (setq skip (text-property-not-all skip (point-max)
-                                                                                   'help-echo nil))
-                                            (goto-char skip)
-                                            (push (make-aj-position
-                                                   :offset (1- skip)
-                                                   :visual-area (car va-list))
-                                                  candidates)
-                                            (setq skip (text-property-any (point) (point-max)
-                                                                          'help-echo nil))))
-                                        (nreverse candidates))))
+  (cl-letf (((symbol-function 'ace-jump-search-candidate)
+             (lambda (str va-list)
+               (let ((skip (text-property-any (point-min) (point-max)
+                                              'help-echo nil))
+                     candidates)
+                 (save-excursion
+                   (while (setq skip (text-property-not-all skip (point-max)
+                                                            'help-echo nil))
+                     (goto-char skip)
+                     (push (make-aj-position
+                            :offset (1- skip)
+                            :visual-area (car va-list))
+                           candidates)
+                     (setq skip (text-property-any (point) (point-max)
+                                                   'help-echo nil))))
+                 (nreverse candidates)))))
     (setq ace-jump-mode-end-hook
           (list `(lambda ()
                    (forward-char 1)

--- a/elfeed-goodies.el
+++ b/elfeed-goodies.el
@@ -4,7 +4,7 @@
 ;;
 ;; Author: Gergely Nagy
 ;; URL: https://github.com/algernon/elfeed-goodies
-;; Package-Requires: ((popwin "1.0.0") (powerline "2.2") (elfeed "2.0.0") (cl-lib "0.5") (noflet "0.0.10") (ace-jump-mode "2.0"))
+;; Package-Requires: ((popwin "1.0.0") (powerline "2.2") (elfeed "2.0.0") (cl-lib "0.5") (ace-jump-mode "2.0"))
 ;;
 ;; This file is NOT part of GNU Emacs.
 ;;

--- a/elfeed-goodies.el
+++ b/elfeed-goodies.el
@@ -4,7 +4,7 @@
 ;;
 ;; Author: Gergely Nagy
 ;; URL: https://github.com/algernon/elfeed-goodies
-;; Package-Requires: ((popwin "1.0.0") (powerline "2.2") (elfeed "2.0.0") (cl-lib "0.5") (ace-jump-mode "2.0"))
+;; Package-Requires: ((popwin "1.0.0") (elfeed "2.0.0") (cl-lib "0.5") (ace-jump-mode "2.0"))
 ;;
 ;; This file is NOT part of GNU Emacs.
 ;;
@@ -63,15 +63,16 @@ utf-8."
   "Setup Elfeed with extras:
 
 * Adaptive header bar and entries.
-* Header bar using powerline.
+* Header bar using powerline (if loaded).
 * Split pane view via popwin."
   (interactive)
   (add-hook 'elfeed-show-mode-hook #'elfeed-goodies/show-mode-setup)
   (add-hook 'elfeed-new-entry-hook #'elfeed-goodies/html-decode-title)
   (when (boundp 'elfeed-new-entry-parse-hook)
     (add-hook 'elfeed-new-entry-parse-hook #'elfeed-goodies/parse-author))
-  (setq elfeed-search-header-function #'elfeed-goodies/search-header-draw
-        elfeed-search-print-entry-function #'elfeed-goodies/entry-line-draw
+  (when (featurep 'powerline)
+    (setq elfeed-search-header-function 'elfeed-goodies/search-header-draw))
+  (setq elfeed-search-print-entry-function #'elfeed-goodies/entry-line-draw
         elfeed-show-entry-switch #'elfeed-goodies/switch-pane
         elfeed-show-entry-delete #'elfeed-goodies/delete-pane
         elfeed-show-refresh-function #'elfeed-goodies/show-refresh--plain)


### PR DESCRIPTION
I humbly propose a few changes to reduce elfeed-goodies's dependencies on external packages and fix one small issue.

First, I noticed that powerline was enabled on my system even though I had switched to a custom modeline for performance reasons.  Eventually I realized that elfeed-goodies was loading powerline.  Unfortunately, loading powerline also enables it (i.e., it adds various hooks), and powerline does not provide a way to disable it once loaded.  Thus I propose changing elfeed-goodies not to load powerline, but instead only to use powerline if it is already loaded.

Next, elfeed-goodies uses `noflet` but not does not use its `this-fn` binding, This use of `noflet` can be substituted by using `cl-letf`.  As `cl-letf` is built-in, I suggest replacing `noflet` with `cl-letf`.  (In my case, elfeed-goodies is the only package installed that requires noflet.)

Finally, `elfeed-goodies/show-ace-link` sets the global value of `ace-jump-mode-end-hook` without resetting it to the old value when the function is done.  I suggest a small fix to bind a value only for the duration of the function and restore it when the function is done.

Commits are described below.


#### Remove dependency on `noflet`

Replace use of `noflet` with use of `cl-letf`.

* `elfeed-goodies-show-mode.el` `(`noflet): Drop requires.
(`cl-lib`): Add requires.
(`elfeed-goodies/show-ace-link`): Replace `noflet` with `cl-letf`.
* `elfeed-goodies.el`: Drop `noflet` from `Package-Requires:` in commentary.


#### Restore value of `ace-jump-mode-end-hook` after jump

* `elfeed-goodies-show-mode.el` (`elfeed-goodies/show-ace-link`): Instead of using `setq`, use `cl-letf` to bind `ace-jump-mode-end-hook` so that its value will be restored at the end of the function.


# Configure powerline only if it is loaded

Do not require powerline, but configure it opportunistically if it is loaded.  The powerline package adds hooks on load, and does not offer a way to disable it after loading, so it is better to leave it to the user to load powerline or not.

* `elfeed-goodies-search-mode.el` (`powerline`): Delete requires.
(`search-header/rhs`, `search-header/draw-wide`, `search-header/draw-tight`, `elfeed-goodies/search-header-draw`): Wrap with `(with-eval-after-load 'powerline ...)`.
* `elfeed-goodies-show-mode.el` (`powerline`): Delete requires.
(`elfeed-goodies/entry-header-line`): Wrap with `(with-eval-after-load 'powerline ...)`.
(`elfeed-goodies/show-mode-setup`): Configure `header-line-format` only if `powerline` is loaded.
* `elfeed-goodies.el:` Delete `powerline` from `Package-Requires:` in commentary.
(`elfeed-goodies/setup`): Configure `elfeed-search-header-function` only if `powerline` is loaded.