### PR TITLE
Replace ace-jump-mode with link-hint

### DIFF
--- a/elfeed-goodies-show-mode.el
+++ b/elfeed-goodies-show-mode.el
@@ -15,7 +15,6 @@
 (require 'elfeed-goodies)
 (require 'powerline)
 (require 'cl-lib)
-(require 'ace-jump-mode)
 (require 'link-hint)
 
 (defcustom elfeed-goodies/show-mode-padding 0

--- a/elfeed-goodies-show-mode.el
+++ b/elfeed-goodies-show-mode.el
@@ -16,6 +16,7 @@
 (require 'powerline)
 (require 'cl-lib)
 (require 'ace-jump-mode)
+(require 'link-hint)
 
 (defcustom elfeed-goodies/show-mode-padding 0
   "Padding on the side of the `*elfeed-entry*' buffer, in characters."
@@ -95,6 +96,11 @@
                    (forward-char 1)
                    (shr-browse-url))))
     (ace-jump-do "foo")))
+
+(defun elfeed-goodies/show-link-hint ()
+  "Select a link to visit with link-hint."
+  (interactive)
+  (link-hint-open-link))
 
 (defun elfeed-goodies/show-mode-setup ()
   (setq header-line-format '(:eval (elfeed-goodies/entry-header-line))

--- a/elfeed-goodies-show-mode.el
+++ b/elfeed-goodies-show-mode.el
@@ -72,31 +72,6 @@
       (insert (propertize "(empty)\n" 'face 'italic)))
     (goto-char (point-min))))
 
-(defun elfeed-goodies/show-ace-link ()
-  "Select a link to visit with ace-jump."
-  (interactive)
-  (cl-letf (((symbol-function 'ace-jump-search-candidate)
-             (lambda  (str va-list)
-               (let ((skip (text-property-any (point-min) (point-max)
-                                              'help-echo nil))
-                     candidates)
-                 (save-excursion
-                   (while (setq skip (text-property-not-all skip (point-max)
-                                                            'help-echo nil))
-                     (goto-char skip)
-                     (push (make-aj-position
-                            :offset (1- skip)
-                            :visual-area (car va-list))
-                           candidates)
-                     (setq skip (text-property-any (point) (point-max)
-                                                   'help-echo nil))))
-                 (nreverse candidates)))))
-    (setq ace-jump-mode-end-hook
-          (list `(lambda ()
-                   (forward-char 1)
-                   (shr-browse-url))))
-    (ace-jump-do "foo")))
-
 (defun elfeed-goodies/show-link-hint ()
   "Select a link to visit with link-hint."
   (interactive)
@@ -106,7 +81,7 @@
   (setq header-line-format '(:eval (elfeed-goodies/entry-header-line))
         left-margin-width elfeed-goodies/show-mode-padding
         right-margin-width elfeed-goodies/show-mode-padding)
-  (define-key elfeed-show-mode-map (kbd "M-v") #'elfeed-goodies/show-ace-link))
+  (define-key elfeed-show-mode-map (kbd "M-v") #'elfeed-goodies/show-link-hint))
 
 (provide 'elfeed-goodies-show-mode)
 

--- a/elfeed-goodies.el
+++ b/elfeed-goodies.el
@@ -4,7 +4,7 @@
 ;;
 ;; Author: Gergely Nagy
 ;; URL: https://github.com/algernon/elfeed-goodies
-;; Package-Requires: ((popwin "1.0.0") (powerline "2.2") (elfeed "2.0.0") (cl-lib "0.5") (ace-jump-mode "2.0"))
+;; Package-Requires: ((popwin "1.0.0") (powerline "2.2") (elfeed "2.0.0") (cl-lib "0.5") (ace-jump-mode "2.0") (link-hint "0.1"))
 ;;
 ;; This file is NOT part of GNU Emacs.
 ;;

--- a/elfeed-goodies.el
+++ b/elfeed-goodies.el
@@ -4,7 +4,7 @@
 ;;
 ;; Author: Gergely Nagy
 ;; URL: https://github.com/algernon/elfeed-goodies
-;; Package-Requires: ((popwin "1.0.0") (powerline "2.2") (elfeed "2.0.0") (cl-lib "0.5") (ace-jump-mode "2.0") (link-hint "0.1"))
+;; Package-Requires: ((popwin "1.0.0") (powerline "2.2") (elfeed "2.0.0") (cl-lib "0.5") (link-hint "0.1"))
 ;;
 ;; This file is NOT part of GNU Emacs.
 ;;


### PR DESCRIPTION
Resolves: #36
Was planning on using avy, but the hard work was already done, courtesy of @noctuid with [link-hint](https://github.com/noctuid/link-hint.el).
Ace-jump-mode is annoying as it uses cl, which causes a deprecated package warning. Link-hint.el uses cl-lib, as does its dependency, avy.
