### PR TITLE
Introduce faces for headers in show mode

### DIFF
--- a/elfeed-goodies-show-mode.el
+++ b/elfeed-goodies-show-mode.el
@@ -27,22 +27,20 @@
   :group 'elfeed-goodies
   :type 'integer)
 
-(defgroup elfeed-goodies-faces nil "Faces for Elfeed goodies." :group 'faces)
-
 (defface elfeed-goodies-show-header-feed
   '((t :inherit 'elfeed-search-feed-face))
   "Elfeed goodies face for feed name in header of entry."
-  :group 'elfeed-goodies-faces)
+  :group 'elfeed-goodies)
 
 (defface elfeed-goodies-show-header-title
   '((t :inherit 'elfeed-search-title-face))
   "Elfeed goodies face for title in header of entry."
-  :group 'elfeed-goodies-faces)
+  :group 'elfeed-goodies)
 
 (defface elfeed-goodies-show-header-tag
   '((t :inherit 'elfeed-search-tag-face))
   "Elfeed goodies face for tags in header of entry."
-  :group 'elfeed-goodies-faces)
+  :group 'elfeed-goodies)
 
 (defun elfeed-goodies/entry-header-line ()
   "Generate elfeed goodies header line.

--- a/elfeed-goodies-show-mode.el
+++ b/elfeed-goodies-show-mode.el
@@ -30,17 +30,17 @@
 (defgroup elfeed-goodies-faces nil "Faces for Elfeed goodies." :group 'faces)
 
 (defface elfeed-goodies-show-header-feed
-  :inherit 'elfeed-search-feed-face
+  '((t :inherit 'elfeed-search-feed-face))
   "Elfeed goodies face for feed name in header of entry."
   :group 'elfeed-goodies-faces)
 
 (defface elfeed-goodies-show-header-title
-  :inherit 'elfeed-search-feed-face
+  '((t :inherit 'elfeed-search-title-face))
   "Elfeed goodies face for title in header of entry."
   :group 'elfeed-goodies-faces)
 
 (defface elfeed-goodies-show-header-tag
-  :inherit 'elfeed-search-feed-face
+  '((t :inherit 'elfeed-search-tag-face))
   "Elfeed goodies face for tags in header of entry."
   :group 'elfeed-goodies-faces)
 

--- a/elfeed-goodies-show-mode.el
+++ b/elfeed-goodies-show-mode.el
@@ -27,11 +27,27 @@
   :group 'elfeed-goodies
   :type 'integer)
 
+(defgroup elfeed-goodies-faces nil "Faces for Elfeed goodies." :group 'faces)
+
+(defface elfeed-goodies-show-header-feed
+  :inherit 'elfeed-search-feed-face
+  "Elfeed goodies face for feed name in header of entry."
+  :group 'elfeed-goodies-faces)
+
+(defface elfeed-goodies-show-header-title
+  :inherit 'elfeed-search-feed-face
+  "Elfeed goodies face for title in header of entry."
+  :group 'elfeed-goodies-faces)
+
+(defface elfeed-goodies-show-header-tag
+  :inherit 'elfeed-search-feed-face
+  "Elfeed goodies face for tags in header of entry."
+  :group 'elfeed-goodies-faces)
+
 (defun elfeed-goodies/entry-header-line ()
   "Generate elfeed goodies header line.
 Return a string containing powerline symbols"
   (let* ((title (elfeed-entry-title elfeed-show-entry))
-         (title-faces (elfeed-search--faces (elfeed-entry-tags elfeed-show-entry)))
          (tags (elfeed-entry-tags elfeed-show-entry))
          (tags-str (mapconcat #'symbol-name tags ", "))
          (date (seconds-to-time (elfeed-entry-date elfeed-show-entry)))
@@ -48,13 +64,13 @@ Return a string containing powerline symbols"
                                           elfeed-goodies/powerline-default-separator
                                           (cdr powerline-default-separator-dir))))
          (lhs (list
-               (powerline-raw (concat " " (propertize tags-str 'face 'elfeed-search-tag-face) " ") 'powerline-active2 'r)
+               (powerline-raw (concat " " (propertize tags-str 'face 'elfeed-goodies-show-header-tag-face) " ") 'powerline-active2 'r)
                (funcall separator-left 'powerline-active2 'powerline-active1)
-               (powerline-raw (concat " " (propertize title 'face title-faces) " ") 'powerline-active1 'l)
+               (powerline-raw (concat " " (propertize title 'face 'elfeed-goodies-show-header-title-face) " ") 'powerline-active1 'l)
                (funcall separator-left 'powerline-active1 'mode-line)))
          (rhs (list
                (funcall separator-right 'mode-line 'powerline-active1)
-               (powerline-raw (concat " " (propertize feed-title 'face 'elfeed-search-feed-face) " ") 'powerline-active1)
+               (powerline-raw (concat " " (propertize feed-title 'face 'elfeed-goodies-show-header-feed-face) " ") 'powerline-active1)
                (funcall separator-right 'powerline-active1 'powerline-active2)
                (powerline-raw (format-time-string "%Y-%m-%d %H:%M:%S %z " date) 'powerline-active2 'l))))
     (concat


### PR DESCRIPTION
Three faces are introduced to be able to customize the entry headers in show mode without changing underlying elfeed faces.

A difference with the previous code is that the face of the title is always `elfeed-goodies-show-header-title-face` (which inherits from `elfeed-search-title-face`), whereas previously the face could depend on the tags that were present.

This should fix #41 and #24.